### PR TITLE
Fix for non existent fs.existsSync function

### DIFF
--- a/lib/raspicam.js
+++ b/lib/raspicam.js
@@ -163,6 +163,7 @@ RaspiCam.prototype.derivativeOpts = function(){
 * 
 **/
 RaspiCam.prototype.createFilepath = function(){
+  fs.existsSync = fs.existsSync || require('path').existsSync;
   if( !fs.existsSync( this.filepath )){
     fs.mkdirSync( this.filepath );
 


### PR DESCRIPTION
In some node.js versions like in Raspberry Pi, fs does not have existsSync method. This commit checks for existence of the mentioned method and in negative case, fs.existsSync is overwriten with the one in 'path'
