### PR TITLE
Correct 'read' event handler in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Require raspicam in your node app, then used the exposed constructor to create a
 	});
 
 	//listen for the "read" event triggered when each new photo/video is saved
-	camera.on("read", function(err, filename){ 
+	camera.on("read", function(err, timestamp, filename){ 
 		//do stuff
 	});
 


### PR DESCRIPTION
The timestamp function parameter was missing from the example handler given for the 'read' event.
