### PR TITLE
Emit exit signal after flag modification

### DIFF
--- a/lib/raspicam.js
+++ b/lib/raspicam.js
@@ -317,10 +317,7 @@ RaspiCam.prototype.addChildProcessListeners = function(){
     derr = data;
   });
 
-  this.child_process.on('close', function (code) {    
-    //emit exit signal for process chaining over time
-    self.emit( "exit", new Date().getTime() );
-
+  this.child_process.on('close', function (code) {
     PROCESS_RUNNING_FLAG = false;
     self.child_process = null;
     child_process = null;
@@ -328,7 +325,10 @@ RaspiCam.prototype.addChildProcessListeners = function(){
     if(this.watcher !== null){
       this.watcher.close();//remove the file watcher
       this.watcher = null;
-    }    
+    }
+
+    //emit exit signal for process chaining over time
+    self.emit("exit", new Date().getTime());
   });
 
 };


### PR DESCRIPTION
An error is thrown when I try to chain photo and timelapse mode. It's due to a bad PROCESS_RUNNING_FLAG value.

Start timelapse (PID 1)
Stop timelapse (PID 1)
Start photo at exit callback (PID 2)
Start timelape at exit callback (PID 3)
...

Because "exit" event is emited before setting PROCESS_RUNNING_FLAG, this flag is set to true by PID 2 and re-set to false by PID 1.
