### PR TITLE
Update examples to use "start" event.

### DIFF
--- a/eg/photo.js
+++ b/eg/photo.js
@@ -8,7 +8,7 @@ var camera = new RaspiCam({
 	timeout: 0 // take the picture immediately
 });
 
-camera.on("started", function( err, timestamp ){
+camera.on("start", function( err, timestamp ){
 	console.log("photo started at " + timestamp );
 });
 

--- a/eg/video.js
+++ b/eg/video.js
@@ -8,7 +8,7 @@ var camera = new RaspiCam({
 	timeout: 5000 // take a 5 second video
 });
 
-camera.on("started", function( err, timestamp ){
+camera.on("start", function( err, timestamp ){
 	console.log("video started at " + timestamp );
 });
 


### PR DESCRIPTION
Updated photo and video examples to use "start" event instead of "started."