### PR TITLE
added .json extension to options

### DIFF
--- a/lib/raspicam.js
+++ b/lib/raspicam.js
@@ -4,8 +4,8 @@ var events = require('events'),
     fs = require("fs"),
     _ = require("lodash"),
     __ = require("../lib/fn.js"),
-    parameters = require("../options").parameters,
-    flags = require("../options").flags;
+    parameters = require("../options.json").parameters,
+    flags = require("../options.json").flags;
 
 
 // maximum timeout allowed by raspicam command


### PR DESCRIPTION
when working with react/webpack/es6 when a file doestn' have an extension, it looks for a .js extension. ../options does not have an extension in raspicam.js so it errors out because it can't find it. Adding the .json extension fixes those errors.