### PR TITLE
Fix watcher close

### DIFF
--- a/lib/raspicam.js
+++ b/lib/raspicam.js
@@ -322,15 +322,14 @@ RaspiCam.prototype.addChildProcessListeners = function(){
     self.child_process = null;
     child_process = null;
 
-    if(this.watcher !== null){
-      this.watcher.close();//remove the file watcher
-      this.watcher = null;
+    if (self.watcher !== null) {
+      self.watcher.close(); //remove the file watcher
+      self.watcher = null;
     }
 
     //emit exit signal for process chaining over time
     self.emit("exit", new Date().getTime());
   });
-
 };
 
 


### PR DESCRIPTION
Since `this` references `child_process`, it can not acces `watcher` property. But `self` variable can.